### PR TITLE
fix: return theme object instead of just string

### DIFF
--- a/packages/gatsby-plugin-eufemia-theme-handler/themeHandler.js
+++ b/packages/gatsby-plugin-eufemia-theme-handler/themeHandler.js
@@ -32,7 +32,7 @@ export function useThemeHandler() {
 
 export function getTheme() {
   if (typeof window === 'undefined') {
-    return defaultTheme
+    return { name: defaultTheme };
   }
   try {
     const data = window.localStorage.getItem(storageId)
@@ -47,13 +47,13 @@ export function getTheme() {
 
     if (!isValidTheme(themeName)) {
       console.error('Not valid themeName:', themeName)
-      return defaultTheme // stop here
+      return { name: defaultTheme }; // stop here
     }
 
     return { ...theme, name: themeName }
   } catch (e) {
     console.error(e)
-    return defaultTheme
+    return { name: defaultTheme }
   }
 }
 

--- a/packages/gatsby-plugin-eufemia-theme-handler/themeHandler.js
+++ b/packages/gatsby-plugin-eufemia-theme-handler/themeHandler.js
@@ -47,7 +47,7 @@ export function getTheme() {
 
     if (!isValidTheme(themeName)) {
       console.error('Not valid themeName:', themeName)
-      return { name: defaultTheme }; // stop here
+      return { name: defaultTheme } // stop here
     }
 
     return { ...theme, name: themeName }

--- a/packages/gatsby-plugin-eufemia-theme-handler/themeHandler.js
+++ b/packages/gatsby-plugin-eufemia-theme-handler/themeHandler.js
@@ -32,7 +32,7 @@ export function useThemeHandler() {
 
 export function getTheme() {
   if (typeof window === 'undefined') {
-    return { name: defaultTheme };
+    return { name: defaultTheme }
   }
   try {
     const data = window.localStorage.getItem(storageId)


### PR DESCRIPTION
I'm pretty sure that we should always return `{ name: "theme name" }`, instead of just `"theme name"`.

Examples of where it doesn't makes sense that it would return just a string like `"theme name"`:
- https://github.com/dnbexperience/gatsby-plugin-eufemia-theme-handler/blob/main/packages/gatsby-plugin-eufemia-theme-handler/themeHandler.js#L59 Spreading a string isn't very useful.
- https://github.com/dnbexperience/gatsby-plugin-eufemia-theme-handler/blob/main/examples/shared/ChangeStyleTheme.tsx#L12 expects to get a object with name property.
