### PR TITLE
fix: make set theme callback param optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ import {
 
 // Example usage
 setTheme({ name })
+// or with callback
+setTheme({ name }, (theme: ThemesItem) =>
+  console.log(`Theme updated to: ${theme.name}`)
+)
+
 const { name } = getTheme()
 const themes = getThemes() // Same as in the plugin config
 

--- a/packages/gatsby-plugin-eufemia-theme-handler/package.json
+++ b/packages/gatsby-plugin-eufemia-theme-handler/package.json
@@ -44,9 +44,10 @@
     "build": "yarn build:cmd && GATSBY_FILES=true yarn build:cmd && yarn build:types",
     "build:cmd": "yarn babel src --extensions .js,.ts,.tsx,.mjs --out-dir .",
     "build:types": "tsc --project tsconfig.json",
-    "clean": "rm -rf themeHandler.js themeHandler.d.js load-eufemia-styles.js inlineScriptProd.js inlineScriptDev.js index.js gatsby-ssr.js gatsby-node.js gatsby-browser.js EventEmitter.js collectThemes.js",
+    "clean": "rm !(src|babel.config.js|.gitignore|LICENSE|*.md|*.json)",
     "watch": "yarn build --watch",
-    "test:types": "tsc --noEmit"
+    "test:types": "tsc --noEmit",
+    "prepublishOnly": "yarn build"
   },
   "dependencies": {
     "gatsby-core-utils": "4.12.0",

--- a/packages/gatsby-plugin-eufemia-theme-handler/src/themeHandler.tsx
+++ b/packages/gatsby-plugin-eufemia-theme-handler/src/themeHandler.tsx
@@ -74,7 +74,7 @@ export function getTheme(): ThemesItem {
 
 export function setTheme(
   themeProps: { name?: string; propMapping?: PropMapping },
-  callback
+  callback?
 ) {
   const theme = { ...getTheme(), ...themeProps } as ThemesItem
 


### PR DESCRIPTION
### Description
Fix/make set theme callback param optional

### Current status
When we want to call the `setTheme` without the callback the typecheck complains, but in fact callback treated as optional in `useTheme` function. 
<img width="741" alt="image" src="https://github.com/dnbexperience/gatsby-plugin-eufemia-theme-handler/assets/16961900/fd2290f7-3663-45cc-af7c-31e778c8b1e8">

### Change
This change adds correct type to callback param.


